### PR TITLE
Fix unresolvable types from 'core'

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,12 @@ const composeTheme = (options: ThemeOptions[]): Theme => {
 };
 
 export {
-  Compose, composeTheme, filterThemeWithPrefix, getThemeCompositionDependencies,
+  Theme, ThemeOptions, Prefix,
+  Compose, ComposedThemesCacheItem, ComposedThemesCacheMap,
+  PrefixedThemesCacheItem, PrefixedThemesCacheMap, ThemeDependencies, ThemeDependenciesCacheMap,
+};
+
+export {
+  composeTheme, filterThemeWithPrefix, getThemeCompositionDependencies,
   getCachedPrefixedTheme, getCachedThemeCompositionDependencies,
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,4 @@
-import {composeTheme, Compose} from '@css-modules-theme/core';
-import {Theme, Prefix} from '@css-modules-theme/core/types';
+import {composeTheme, Compose, Theme, Prefix} from '@css-modules-theme/core';
 
 export {Theme, Prefix};
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -84,6 +84,8 @@ export const composeThemeFromProps = <T extends ThemeProps>(
   return composeTheme(themes);
 };
 
+type UnionOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
+
 /**
  * Helper on top of composeThemeFromProps,
  * that returns new props object with deprived theme* properties from original one and mixed result `theme`
@@ -97,7 +99,7 @@ export const composeThemeFromProps = <T extends ThemeProps>(
  */
 export const mixThemeWithProps = <T extends ThemeProps, K extends T & {theme: Theme}>(
   ownTheme: Theme, propsOrContext: T | T[], options: ComposeOptions & {props?: T} = {}
-): Omit<K, 'themePrefix' | 'themeCompose' | 'themeNoCache' | 'themeNoParseComposes'> => {
+): UnionOmit<K, 'themePrefix' | 'themeCompose' | 'themeNoCache' | 'themeNoParseComposes'> => {
   const props = typeof options.props === 'object' ? options.props : Array.isArray(propsOrContext) ? propsOrContext[0] : propsOrContext;
   const {
     themePrefix, themeCompose, themeNoCache, themeNoParseComposes, ...restProps
@@ -105,7 +107,7 @@ export const mixThemeWithProps = <T extends ThemeProps, K extends T & {theme: Th
 
   restProps.theme = composeThemeFromProps(ownTheme, propsOrContext, options);
 
-  return restProps;
+  return restProps as UnionOmit<K, 'themePrefix' | 'themeCompose' | 'themeNoCache' | 'themeNoParseComposes'>;
 };
 
 export {Compose};


### PR DESCRIPTION
## Problem
In the `@css-modules-theme/react`, importing types from the `core` like below only works when TS can find the correct path mapping from `tsconfig.json`.
```
import {Theme, Prefix} from '@css-modules-theme/core/types';
```

However, `tsconfig.json` is not published to the release distribution, so the types `Theme` and `Prefix` can't be found.

## Solution

Re-exporting the types in `@css-modules-theme/core/index.ts` and do
```
import {Theme, Prefix} from '@css-modules-theme/core';
```
in `@css-modules-theme/react`.